### PR TITLE
FS1 | [Friend Screen] Create Post card with picture

### DIFF
--- a/frontend/VolunteerOne/components/PostWithImage.js
+++ b/frontend/VolunteerOne/components/PostWithImage.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StyleSheet, Image } from 'react-native';
+import { Block, Text, theme } from 'galio-framework';
+
+
+class PostWithImage extends React.Component {
+  render() {
+    const { item, horizontal, full, style, imageStyle } = this.props;
+    
+    const cardContainer = [styles.card, styles.shadow, style];
+    const profileImageContainer = [styles.profileImageContainer,
+      styles.shadow
+    ];
+    const imgContainer = [styles.imageContainer,
+      horizontal ? styles.horizontalStyles : styles.verticalStyles,
+      styles.shadow
+    ];
+    const imageStyles = [
+      styles.fullImage,
+      imageStyle
+    ];
+
+
+    return (
+      <Block row={horizontal} card flex style={cardContainer}>
+        <Block style={[ styles.cardContainer, { flexDirection: 'column', } ]}>  
+        {/* Displays info. about the post author. */}
+          <Block style={[profileImageContainer , {flexDirection: 'row', } ]}>
+            <Image source={{uri: item.profileImage}} style={styles.profileImage} />
+            <Block style={styles.cardTitleContainer}>            
+              <Text size={18} bold style={styles.cardTitle}>{item.author}</Text>
+              <Text size={14} style={styles.cardTitle}>{item.date}</Text>
+            </Block>
+          </Block>  
+        {/* Displays user description. */}
+            <Block style={styles.postDescriptionContainer}>
+              <Text size={14} style={styles.cardDescription}>{item.description}</Text>
+            </Block>
+          </Block>
+          <Block flex style={imgContainer}>
+            <Image source={{uri: item.image}} style={imageStyles} />
+          </Block>
+
+      </Block>
+    );
+  }
+}
+
+PostWithImage.propTypes = {
+  item: PropTypes.object,
+  full: PropTypes.bool,
+  imageStyle: PropTypes.any,
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.COLORS.WHITE,
+    marginVertical: theme.SIZES.BASE,
+    borderWidth: 0,
+    minHeight: 150,
+    marginBottom: 16
+  },
+  cardTitleContainer: {
+    paddingLeft: 10,
+    paddingTop: 20
+  },
+  cardDescription: {
+    padding: theme.SIZES.BASE / 2
+  },
+  imageContainer: {
+    borderRadius: 2,
+    elevation: 1,
+    overflow: 'hidden',
+  },
+  horizontalImage: {
+    height: 122,
+    width: 'auto',
+  },
+  profileImageContainer: {
+    paddingLeft: 10,
+    paddingTop: 10
+  },
+  profileImage: {
+    width: 70,
+    height: 70,
+    borderRadius: 70/2
+  },
+  fullImage: {
+    height: 215
+  },
+  postDescriptionContainer: {
+    margin: theme.SIZES.BASE,
+  },
+  shadow: {
+    shadowColor: theme.COLORS.BLACK,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    shadowOpacity: 0.1,
+    elevation: 2,
+  },
+});
+
+export default PostWithImage;

--- a/frontend/VolunteerOne/components/PostWithImage.js
+++ b/frontend/VolunteerOne/components/PostWithImage.js
@@ -72,6 +72,7 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     elevation: 1,
     overflow: 'hidden',
+    padding: 6
   },
   horizontalImage: {
     height: 122,

--- a/frontend/VolunteerOne/components/PostWithoutImage.js
+++ b/frontend/VolunteerOne/components/PostWithoutImage.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StyleSheet, Image } from 'react-native';
+import { Block, Text, theme } from 'galio-framework';
+
+
+class PostWithoutImage extends React.Component {
+  render() {
+    const {item, horizontal, style} = this.props;
+    
+    const cardContainer = [styles.card, styles.shadow, style];
+    const profileImageContainer = [styles.profileImageContainer,
+      styles.shadow
+    ];
+
+    return (
+      <Block row={horizontal} card flex style={cardContainer}>
+        {/* Profile Image */}
+        <Block style={[ styles.cardContainer, { flexDirection: 'column', } ]}>  
+        {/* Displays info. about the post author. */}
+          <Block style={[profileImageContainer , {flexDirection: 'row', } ]}>
+            <Image source={{uri: item.profileImage}} style={styles.fullImage} />
+            <Block style={styles.cardTitleContainer}>            
+              <Text size={18} bold style={styles.cardTitle}>{item.author}</Text>
+              <Text size={14} style={styles.cardTitle}>{item.date}</Text>
+            </Block>
+          </Block>  
+        {/* Displays user description. */}
+            <Block style={styles.postDescriptionContainer}>
+              <Text size={14} style={styles.cardDescription}>{item.description}</Text>
+            </Block>
+          </Block>
+      </Block>
+    );
+  }
+}
+
+PostWithoutImage.propTypes = {
+  item: PropTypes.object,
+  horizontal: PropTypes.bool,
+  full: PropTypes.bool,
+  ctaColor: PropTypes.string,
+  imageStyle: PropTypes.any,
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.COLORS.WHITE,
+    marginVertical: theme.SIZES.BASE,
+    borderWidth: 0,
+    minHeight: 150,
+    marginBottom: 16
+  },
+  cardTitleContainer: {
+    paddingLeft: 10,
+    paddingTop: 20
+  },
+  cardDescription: {
+    padding: theme.SIZES.BASE / 2
+  },
+  profileImageContainer: {
+    paddingLeft: 10,
+    paddingTop: 10
+  },
+  fullImage: {
+    width: 70,
+    height: 70,
+    borderRadius: 70/2
+  },
+  postDescriptionContainer: {
+    margin: theme.SIZES.BASE,
+  },
+  shadow: {
+    shadowColor: theme.COLORS.BLACK,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    shadowOpacity: 0.1,
+    elevation: 2,
+  },
+});
+
+export default PostWithoutImage;

--- a/frontend/VolunteerOne/components/index.js
+++ b/frontend/VolunteerOne/components/index.js
@@ -7,6 +7,7 @@ import Input from './Input';
 import Switch from './Switch';
 import Select from './Select';
 import PostWithoutImage from './PostWithoutImage';
+import PostWithImage from './PostWithImage';
 
 
 export {
@@ -18,5 +19,6 @@ export {
   Header,
   Switch, 
   Select,
-  PostWithoutImage
+  PostWithoutImage,
+  PostWithImage
 };

--- a/frontend/VolunteerOne/components/index.js
+++ b/frontend/VolunteerOne/components/index.js
@@ -6,6 +6,8 @@ import Header from './Header';
 import Input from './Input';
 import Switch from './Switch';
 import Select from './Select';
+import PostWithoutImage from './PostWithoutImage';
+
 
 export {
   Button,
@@ -15,5 +17,6 @@ export {
   Input,
   Header,
   Switch, 
-  Select
+  Select,
+  PostWithoutImage
 };

--- a/frontend/VolunteerOne/constants/posts.js
+++ b/frontend/VolunteerOne/constants/posts.js
@@ -2,8 +2,16 @@ export default [
     {
       author: 'John Doe',
       date: '2 hr. ago',  // TODO: change date to dynamic
-      profileImage: 'https://images.unsplash.com/photo-1516559828984-fb3b99548b21?ixlib=rb-1.2.1&auto=format&fit=crop&w=2100&q=80',
+      profileImage: 'https://images.pexels.com/photos/9324374/pexels-photo-9324374.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
       description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
       horizontal: true
+    },
+    {
+      author: 'Jane Doe',
+      date: '30 min. ago',  // TODO: change date to dynamic
+      profileImage: 'https://images.pexels.com/photos/6994744/pexels-photo-6994744.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      horizontal: true,
+      image: 'https://images.pexels.com/photos/5029859/pexels-photo-5029859.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1'
     },
   ];

--- a/frontend/VolunteerOne/constants/posts.js
+++ b/frontend/VolunteerOne/constants/posts.js
@@ -1,0 +1,9 @@
+export default [
+    {
+      author: 'John Doe',
+      date: '2 hr. ago',  // TODO: change date to dynamic
+      profileImage: 'https://images.unsplash.com/photo-1516559828984-fb3b99548b21?ixlib=rb-1.2.1&auto=format&fit=crop&w=2100&q=80',
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+      horizontal: true
+    },
+  ];

--- a/frontend/VolunteerOne/screens/Friends/index.js
+++ b/frontend/VolunteerOne/screens/Friends/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet, Dimensions, ScrollView } from 'react-native';
 import { Block, theme } from 'galio-framework';
 
-import { PostWithoutImage } from '../../components';
+import { PostWithoutImage, PostWithImage } from '../../components';
 import posts from '../../constants/posts';
 
 const { width } = Dimensions.get('screen');
@@ -15,6 +15,9 @@ class Home extends React.Component {
         contentContainerStyle={styles.posts}>
         <Block flex>
           <PostWithoutImage item={posts[0]} />
+        </Block>
+        <Block flex>
+          <PostWithImage item={posts[1]} />
         </Block>
       </ScrollView>
     )

--- a/frontend/VolunteerOne/screens/Friends/index.js
+++ b/frontend/VolunteerOne/screens/Friends/index.js
@@ -2,24 +2,19 @@ import React from 'react';
 import { StyleSheet, Dimensions, ScrollView } from 'react-native';
 import { Block, theme } from 'galio-framework';
 
-import { Card } from '../../components';
-import articles from '../../constants/articles';
+import { PostWithoutImage } from '../../components';
+import posts from '../../constants/posts';
+
 const { width } = Dimensions.get('screen');
 
 class Home extends React.Component {
-  renderArticles = () => {
+  renderPosts = () => {
     return (
       <ScrollView
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={styles.articles}>
+        contentContainerStyle={styles.posts}>
         <Block flex>
-          <Card item={articles[0]} horizontal  />
-          <Block flex row>
-            <Card item={articles[1]} style={{ marginRight: theme.SIZES.BASE }} />
-            <Card item={articles[2]} />
-          </Block>
-          <Card item={articles[3]} horizontal />
-          <Card item={articles[4]} full />
+          <PostWithoutImage item={posts[0]} />
         </Block>
       </ScrollView>
     )
@@ -28,7 +23,7 @@ class Home extends React.Component {
   render() {
     return (
       <Block flex center style={styles.home}>
-        {this.renderArticles()}
+        {this.renderPosts()}
       </Block>
     );
   }
@@ -38,7 +33,7 @@ const styles = StyleSheet.create({
   home: {
     width: width,    
   },
-  articles: {
+  posts: {
     width: width - theme.SIZES.BASE * 2,
     paddingVertical: theme.SIZES.BASE,
   },


### PR DESCRIPTION
# FS1 | Friend Screen
> Team member: @cerasamson 
> Use Case ID: FS1

Fixes #73 

## Expected Behavior
[WIP] Component behaves almost identical to #87. Expands the Post Without Image component to include an image.

It will display on the initial screen when the "Friends" bottom tab is selected.
#### Example of the component in the Friends Home Screen is shown below:
![Screen Shot 2023-03-06 at 4 32 32 PM](https://user-images.githubusercontent.com/59468977/223288008-2eab0599-0f54-4cb2-97a1-732694a4056e.png)

### - Considerations [optional]
Extra cases to conider 
1. Missing engagement buttons (Like/Comment buttons) - is WIP
2. Ability to click on author's profile picture to take user to the respective profile
3. Minimize post if > certain limit - add expand button - **image will be hidden**
4. Will be working on adjusting picture margins to be centered in the post container.