### PR TITLE
38 crud operations for organizations

### DIFF
--- a/backend/controllers/organizationController.go
+++ b/backend/controllers/organizationController.go
@@ -1,0 +1,186 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/VolunteerOne/volunteer-one-app/backend/database"
+	"github.com/VolunteerOne/volunteer-one-app/backend/models"
+	"github.com/gin-gonic/gin"
+)
+
+type OrganizationController struct{}
+
+var organizationModel = new(models.Organization)
+
+//Create ...
+func (controller OrganizationController) Create(c *gin.Context) {
+	var err error
+	db := database.GetDatabase()
+
+	// Declare a struct for the desired request body
+	var body struct {
+		Name string
+		Description string 
+		Verified bool 
+		Interests string 
+	}
+
+	// Bind struct to context and check for error
+	err = c.Bind(&body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Request body is invalid",
+		})
+
+		return
+	}
+
+	// Create the object in the database
+	object := models.Organization{
+		Name:  body.Name,
+		Description: body.Description,
+		Verified: body.Verified,
+		Interests: body.Interests,
+	}
+
+	result := db.Create(&object)
+
+	if result.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Creation failed",
+		})
+
+		return
+	}
+
+	// Respond
+	c.JSON(http.StatusOK, object)
+}
+
+func (controller OrganizationController) All(c *gin.Context) {
+	// var err error
+	db := database.GetDatabase()
+	var orgs []models.Organization
+
+	// Get objects from database
+	result := db.Find(&orgs)
+
+	if result.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Could not retrieve objects",
+		})
+
+		return
+	}
+
+	// Return the array of objects
+	c.JSON(http.StatusOK, orgs)
+
+}
+
+func (controller OrganizationController) One(c *gin.Context) {
+	db := database.GetDatabase()
+
+	// Get the id
+	id := c.Param("id")
+
+	// Get object from the database
+	var org models.Organization
+	result := db.First(&org, id)
+
+	if result.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Could not retrieve object",
+		})
+
+		return
+	}
+
+	// Return the object
+	c.JSON(http.StatusAccepted, org)
+}
+
+func (controller OrganizationController) Update(c *gin.Context) {
+
+	db := database.GetDatabase()
+
+	// Get the existing object
+	id := c.Param("id")
+	var org models.Organization
+	result := db.Find(&org, id)
+
+	if result.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Could not retrieve object",
+		})
+
+		return
+	}
+
+	// Get updates from the body
+	var body struct {
+		Name string
+		Description string 
+		Verified bool 
+		Interests string 
+	}
+
+	if err := c.Bind(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Request body is invalid",
+		})
+
+		return
+	}
+
+	org.Name = body.Name
+	org.Description = body.Description
+	org.Verified = body.Verified
+	org.Interests = body.Interests
+
+	// Update the object
+	result = db.Save(&org)
+	if result.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Could not update object",
+		})
+
+		return
+	}
+
+	// Respond
+	c.JSON(http.StatusOK, org)
+}
+
+func (controller OrganizationController) Delete(c *gin.Context) {
+	db := database.GetDatabase()
+
+	// Get the existing object
+	id := c.Param("id")
+	var org models.Organization
+	result := db.Find(&org, id)
+
+	if result.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Could not retrieve object",
+		})
+
+		return
+	}
+
+	// Delete the object
+	result = db.Delete(&org)
+	if result.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Could not delete object",
+		})
+
+		return
+	}
+
+	// Respond
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Object deleted successfully",
+	})
+
+}

--- a/backend/models/initialization.go
+++ b/backend/models/initialization.go
@@ -14,6 +14,7 @@ var tables = []Model{
 	&Object{},
 	&User{},
 	&Organization{},
+	&Users{},
 }
 
 func Init() {

--- a/backend/models/initialization.go
+++ b/backend/models/initialization.go
@@ -13,6 +13,7 @@ type Model interface {
 var tables = []Model{
 	&Object{},
 	&User{},
+	&Organization{},
 }
 
 func Init() {

--- a/backend/models/organizationModel.go
+++ b/backend/models/organizationModel.go
@@ -1,0 +1,11 @@
+package models
+
+import "gorm.io/gorm"
+
+type Organization struct {
+	gorm.Model
+	Name string `gorm: "unique"`
+	Description string 
+	Verified bool 
+	Interests string 
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -35,7 +35,15 @@ func NewRouter() *gin.Engine {
 
 	loginGroup.GET("/:email/:password", loginController.Login)
 
-    
+	organizationGroup := router.Group("organization")
+	{
+		organization := new(controllers.OrganizationController)
+		organizationGroup.POST("/", organization.Create)
+		organizationGroup.GET("/", organization.All)
+		organizationGroup.GET("/:id", organization.One)
+		organizationGroup.DELETE("/:id", organization.Delete)
+		organizationGroup.PUT("/:id", organization.Update)
+	}
 
 	// objectGroup := router.Group("object")
 	// {


### PR DESCRIPTION
# [UC1.4] | [Organization Creation]
> Team member: David Zeleniak
> Use Case ID: UC1.4

Fixes #38 

## Expected Behavior
An "organization" endpoint has been added to the API.
The organization controller adds crud operations for creating, updating, and deleting organizations.
API users will now be able to make GET POST PUT and DELETE requests on the organization endpoint.

## Usage
<img width="825" alt="image" src="https://user-images.githubusercontent.com/20673621/227830816-6b0f3517-8487-4728-aec2-d892f3bc808e.png">
<img width="817" alt="image" src="https://user-images.githubusercontent.com/20673621/227830881-8793d32b-9596-4b84-925c-4f07a6f1923a.png">
<img width="814" alt="image" src="https://user-images.githubusercontent.com/20673621/227831088-48b108dc-dcd4-4e03-83a6-22e774efcd46.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/20673621/227831305-55877502-6383-4e6d-ad66-eb8d50bdb087.png">


