### PR TITLE
[Frontend ] | Create button to open New Announcement modal

### DIFF
--- a/frontend/VolunteerOne/components/Modals/NewAnnouncementModal.js
+++ b/frontend/VolunteerOne/components/Modals/NewAnnouncementModal.js
@@ -1,133 +1,126 @@
-// This file was added by Matt
-// It contains the component for a New Announcement modal item 
-// which is dispayed when a user wants to make a new announcement
-// it works like a popup.
 
-import React from 'react';
-import {Alert, Modal, StyleSheet, Pressable, View, Dimensions, TextInput, Image} from 'react-native';
-import { Block, Text, theme } from 'galio-framework';
+import React from "react";
+import {
+  Alert,
+  Modal,
+  StyleSheet,
+  Pressable,
+  View,
+  Dimensions,
+  TextInput,
+  Image,
+} from "react-native";
+import { Block, Text, theme } from "galio-framework";
 import { argonTheme } from "../../constants";
+import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
 
 const { width, height } = Dimensions.get("screen");
 
-function handleCreateAnnBtnClick() {
-// write function for create announcement button here
 
-}
+/** ==================================== New Announcement Modal Component ==================================== **/
 
-class NewAnouncementModal extends React.Component {
+class NewAnnouncementModal extends React.Component {
+  
   state = {
-    modalVisible: false,
+    user: "",
+    datetime: new Date(),
+    title: "",
+    description: "",
   };
 
-
   render() {
-    const {modalVisible} = this.state;
+
+    const handleAddNewClick = () => {
+      console.log("Adding New Announcement ",this.state)
+      // post to db
+    }
+
     return (
       <View style={styles.centeredView}>
-        
         <Modal
           animationType="fade"
           transparent={true}
-          visible={modalVisible}
+          visible={this.props.visible}
           onRequestClose={() => {
-            Alert.alert('Modal has been closed.');
-            this.setState({modalVisible: !modalVisible});
-          }}>
-             
-
-          <View style={styles.centeredView}>    
+            console.log("Modal has been closed.");
+            this.props.setState();
+          }}
+        >
+          <View style={[styles.centeredView, styles.modalViewOutside]}>
             <View style={styles.modalView}>
-              {/* x icont to exit modal */}
+              {/* exit modal */}
               <Pressable
-                onPress={() => this.setState({modalVisible: !modalVisible})}
-                style={{alignItems: 'flex-end'}}>
-                <Image
-                style={styles.exit}
-                source={require('../../assets/imgs/exit.png')} />
+                onPress={() => this.props.setState()}
+                style={{ alignItems: "flex-end", margin: 5 }}
+              >
+                <MaterialCommunityIcons
+                  size={24}
+                  name="close"
+                  color={theme.COLORS.ICON}
+                />
               </Pressable>
-              
-              <View style={styles.modalViewInside}>
-   
-                <Text style={styles.header}>
-                  New Announcement 
-                </Text>
-     
 
-                <Text style={styles.secondaryHeader}>
-                  Post title
-                </Text>
+              <View style={styles.modalViewInside}>
+                <Text style={styles.header}>New Announcement</Text>
+
+                <Text style={styles.secondaryHeader}>Post title</Text>
                 <Block width={width * 0.8 - 20} style={{ marginBottom: 15 }}>
                   <TextInput
-                    style={styles.input} 
+                    style={styles.input}
                     placeholder="Enter a title"
-                    placeholderTextColor={"lightgrey"}                  
-                    // onChangeText={handleTitleInput}
+                    placeholderTextColor={"lightgrey"}
+                    onChangeText={(e) => this.setState({ title: e })}
                   />
                 </Block>
 
-                <Text style={styles.secondaryHeader}>
-                  Description
-                </Text>
-                <Block width={width * 0.8 - 20}  style={{ marginBottom: 15 }}>
+                <Text style={styles.secondaryHeader}>Description</Text>
+                <Block width={width * 0.8 - 20} style={{ marginBottom: 15 }}>
                   <TextInput
                     style={styles.input}
                     placeholder="Provide announcement details here"
                     placeholderTextColor={"lightgrey"}
                     height={height * 0.3}
-                    textAlignVertical={'top'}
+                    textAlignVertical={"top"}
                     paddingTop={10}
                     multiline={true}
-                    // onChangeText={handleDescriptionInput}
+                    onChangeText={(e) => this.setState({ description: e })}
                   />
                 </Block>
 
                 <Pressable
                   style={[styles.button, styles.buttonClose]}
-                  onPress={() => {this.setState({modalVisible: !modalVisible}); handleCreateAnnBtnClick();}}>
+                  onPress={() => {
+                    this.props.setState(); 
+                    handleAddNewClick();
+                  }}
+                >
                   <Text style={styles.textStyle}>CREATE ANNOUNCEMENT</Text>
                 </Pressable>
-
               </View>
             </View>
           </View>
         </Modal>
-        {/* button that shows before opening modal */}
-        <Pressable
-          style={[styles.button, styles.buttonOpen]}
-          onPress={() => this.setState({modalVisible: true})}>
-          <Text style={styles.textStyle}>New Announcement</Text>
-        </Pressable>
       </View>
     );
   }
 }
 
 const styles = StyleSheet.create({
-  exit: {
-    margin:10,
-    marginBottom: 0,
-    justifyContent:"flex-end",
-    width: 15,
-    height: 15,
-  },
-
   header: {
     fontSize: 25,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     color: "#525F7F",
     marginBottom: 20,
   },
   secondaryHeader: {
     fontSize: 17,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     color: "#525F7F",
-    marginBottom:5,
+    marginBottom: 5,
   },
-  
   input: {
     borderColor: argonTheme.COLORS.BORDER,
-    borderWidth: .5,
+    borderWidth: 0.5,
     borderRadius: 5,
     height: 44,
     backgroundColor: "#FFFFFF",
@@ -137,16 +130,13 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     elevation: 2,
     paddingLeft: 10,
-   
   },
   modalView: {
-    margin: 20,
-    backgroundColor: 'white',
-    paddingTop: 0,
-    shadowColor: '#000',
+    backgroundColor: "white",
+    shadowColor: "#000",
     shadowOffset: {
-      width: 0,
-      height: 2,
+      width: 5,
+      height: 5,
     },
     shadowOpacity: 0.1,
     shadowRadius: 4,
@@ -157,11 +147,13 @@ const styles = StyleSheet.create({
 
   centeredView: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginTop: 22,
+    justifyContent: "center",
+    alignItems: "center",
+    // marginTop: 22,
   },
-
+  modalViewOutside: {
+    backgroundColor: 'rgba(52, 52, 52, 0.75)',    // changed opacity of background when modal is open 
+  },
   modalViewInside: {
     padding: 25,
     paddingTop: 0,
@@ -171,24 +163,16 @@ const styles = StyleSheet.create({
     padding: 10,
     elevation: 2,
   },
-  buttonOpen: {
-    backgroundColor: '#F194FF',
-  },
   buttonClose: {
-    backgroundColor: '#5e72e4',
+    backgroundColor: "#5e72e4",
     padding: 10,
-    marginTop:10,
+    marginTop: 10,
   },
   textStyle: {
-    color: 'white',
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
-  modalText: {
-    marginBottom: 15,
-    textAlign: 'center',
+    color: "white",
+    fontWeight: "bold",
+    textAlign: "center",
   },
 });
 
-
-export default NewAnouncementModal;
+export default NewAnnouncementModal;

--- a/frontend/VolunteerOne/screens/Announcements/index.js
+++ b/frontend/VolunteerOne/screens/Announcements/index.js
@@ -1,10 +1,17 @@
 import React from "react";
-import { StyleSheet, Dimensions, ScrollView } from "react-native";
+import { StyleSheet, Dimensions, ScrollView, Text } from "react-native";
+import { Button } from "../../components";
 import { Block, theme } from "galio-framework";
 import EventCard from "../../components/EventCard";
 import { following } from "../../constants/announcements_followingtab";
 import { all } from "../../constants/announcements_alltab";
+import argonTheme from "../../constants/Theme";
+import NewAnnouncementModal from "../../components/Modals/NewAnnouncementModal";
+import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
+
 const { width } = Dimensions.get("screen");
+
+/** ==================================== Announcements Tab ==================================== **/
 
 class Announcements extends React.Component {
   renderArticles = () => {
@@ -40,9 +47,43 @@ class Announcements extends React.Component {
     );
   };
 
+  state = {
+    modalVisible: false,
+  };
+
   render() {
+    const { modalVisible } = this.state;
+
+    const handleModalVisible = () => {
+      this.setState({ modalVisible: !modalVisible });
+    };
+
     return (
       <Block flex center style={styles.home}>
+        <Block middle>
+          <Button
+            color="primary"
+            style={styles.button}
+            onPress={() => handleModalVisible()}
+          >
+            <Block row middle>
+              <MaterialCommunityIcons
+                size={24}
+                name="plus-box-outline"
+                color={theme.COLORS.WHITE}
+              />
+              <Text bold size={14} style={styles.buttonTitle}>
+                New Announcement
+              </Text>
+            </Block>
+          </Button>
+        </Block>
+        {modalVisible && (
+          <NewAnnouncementModal
+            visible={this.state.modalVisible}
+            setState={handleModalVisible}
+          />
+        )}
         {this.renderArticles()}
       </Block>
     );
@@ -56,6 +97,17 @@ const styles = StyleSheet.create({
   articles: {
     width: width - theme.SIZES.BASE * 2,
     paddingVertical: theme.SIZES.BASE,
+  },
+  button: {
+    marginTop: theme.SIZES.BASE,
+    marginBottom: 0,
+    width: width * 0.9,
+  },
+  buttonTitle: {
+    paddingLeft: 5,
+    lineHeight: 19,
+    fontWeight: "600",
+    color: argonTheme.COLORS.WHITE,
   },
 });
 


### PR DESCRIPTION
# [#137 ] | Create button to open New Announcement modal
> Team member: @carmen-lee 
> Use Case ID:

Fixes #137 

## Expected Behavior
Created a button that will launch New Announcement modal. Form will intake data and console log it.

### - Considerations [optional]
Extra cases to consider 
1. Image attachments

### - Evidence/Logs
Please include any relevant log snippets or images to support issue.

<img width="442" alt="Screen Shot 2023-04-03 at 12 53 44 PM" src="https://user-images.githubusercontent.com/66394221/229613029-c00aa58b-07ca-4f7e-9b97-6a3e46a0d815.png">

<img width="442" alt="Screen Shot 2023-04-03 at 12 54 10 PM" src="https://user-images.githubusercontent.com/66394221/229613109-1167cf39-9a04-4ca3-b272-8ecfb1181a61.png">

Output:
`Adding New Announcement  
{"datetime": 2023-04-03T19:53:49.898Z, "description": "Test Description", "title": "Test Title", "user": ""}`
