### PR TITLE
Refactored to support password hashing

### DIFF
--- a/backend/repository/loginRepository.go
+++ b/backend/repository/loginRepository.go
@@ -12,7 +12,7 @@ type LoginRepository interface {
 	FindUserFromEmail(string, models.Users) (models.Users, error)
 	SaveResetCodeToUser(uuid.UUID, models.Users) error
 	CreateUser(models.Users) (models.Users, error)
-	ChangePassword(string, models.Users) error
+	ChangePassword([]byte, models.Users) error
 }
 
 type loginRepository struct {
@@ -55,8 +55,9 @@ func (l loginRepository) CreateUser(user models.Users) (models.Users, error) {
 	return user, err
 }
 
-func (l loginRepository) ChangePassword(newPassword string, user models.Users) error {
+func (l loginRepository) ChangePassword(newPassword []byte, user models.Users) error {
 	log.Println("Entering ChangePassword repository")
-	user.Password = newPassword
+
+	user.Password = string(newPassword)
 	return l.DB.Save(&user).Error
 }

--- a/backend/service/loginService.go
+++ b/backend/service/loginService.go
@@ -12,9 +12,10 @@ import (
 type LoginService interface {
 	FindUserFromEmail(string, models.Users) (models.Users, error)
 	SaveResetCodeToUser(uuid.UUID, models.Users) error
-	ChangePassword(string, models.Users) error
+	ChangePassword([]byte, models.Users) error
 	CreateUser(models.Users) (models.Users, error)
 	HashPassword([]byte) ([]byte, error)
+	CompareHashedAndUserPass([]byte, string) error
 }
 
 type loginService struct {
@@ -36,7 +37,7 @@ func (l loginService) SaveResetCodeToUser(resetCode uuid.UUID, user models.Users
 	return l.loginRepository.SaveResetCodeToUser(resetCode, user)
 }
 
-func (l loginService) ChangePassword(newPassword string, user models.Users) error {
+func (l loginService) ChangePassword(newPassword []byte, user models.Users) error {
 	return l.loginRepository.ChangePassword(newPassword, user)
 }
 
@@ -48,4 +49,9 @@ func (l loginService) CreateUser(user models.Users) (models.Users, error) {
 func (l loginService) HashPassword(password []byte) ([]byte, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), 10)
 	return hash, err
+}
+
+func (l loginService) CompareHashedAndUserPass(hashedPassword []byte, stringPassword string) error {
+	err := bcrypt.CompareHashAndPassword(hashedPassword, []byte(stringPassword))
+	return err
 }


### PR DESCRIPTION
#158 
> Team member: Edward

Fixes #158 

## Expected Behavior
Refactored login so that it supports password hashing. Login now hashes the incoming password and compares it with the hashed password in the database. Reset Password also saves the new password as a hashed password inside of the database.

## Issue
Previously, my functions did not take into account that the passwords were to be stored in the database as a hashed []byte. Refactored in order to accommodate this functionality.

