### PR TITLE
added like button and simplified styling for event details

### DIFF
--- a/frontend/VolunteerOne/components/EventDetails/LikeButton.js
+++ b/frontend/VolunteerOne/components/EventDetails/LikeButton.js
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from "react";
+import { Pressable, StyleSheet, Alert } from "react-native";
+import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
+const LikeButton = () => {
+  const [liked, setLiked] = useState(false);
+
+  useEffect(() => {
+    if (liked) {
+      Alert.alert("Event bookmarked");
+    }
+  }, [liked]);
+  return (
+    <Pressable
+      onPress={() => {
+        setLiked((isLiked) => !isLiked);
+      }}
+      style={styles.likeButton}
+    >
+      <MaterialCommunityIcons
+        name={liked ? "heart" : "heart-outline"}
+        size={32}
+        color={liked ? "red" : "black"}
+      />
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  likeButton: {
+    marginLeft: "auto",
+  },
+});
+
+export default LikeButton;

--- a/frontend/VolunteerOne/components/EventDetails/index.js
+++ b/frontend/VolunteerOne/components/EventDetails/index.js
@@ -3,7 +3,8 @@ import { Block, Text, Button } from "galio-framework";
 import { argonTheme } from "../../constants";
 import { events } from "../../constants/HomeTab/event_details";
 import { useState } from "react";
-const { width, height } = Dimensions.get("screen");
+import LikeButton from "./LikeButton";
+const { width } = Dimensions.get("screen");
 /*
 Description:
   This component displays the event details of an organization's post when a user presses
@@ -60,8 +61,11 @@ const EventDetails = ({ eventID }) => {
     //Event Details gets returned
     return (
       <Block style={[styles.card, styles.shadowProp]}>
-        <Block style={styles.headerContent}>
-          <Text style={styles.headerTitle}>{eventDetails["title"]}</Text>
+        <Block gap={8}>
+          <Block row>
+            <Text style={styles.headerTitle}>{eventDetails["title"]}</Text>
+            <LikeButton />
+          </Block>
           <Text style={styles.headerText}>{eventDetails["organization"]}</Text>
           <Text style={styles.headerText}>{eventDetails["datePosted"]}</Text>
         </Block>
@@ -118,11 +122,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: 500,
   },
-  headerContent: {
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    gap: 8,
-  },
   descriptionTitle: {
     color: "#5E72E4",
     fontWeight: 700,
@@ -137,8 +136,6 @@ const styles = StyleSheet.create({
   },
   body: {
     marginTop: 10,
-    flexDirection: "column",
-    justifyContent: "flex-start",
     gap: 8,
     marginBottom: 10,
   },


### PR DESCRIPTION

> Team member: @Mtessier809 

## Expected Behavior
When like button is pressed, the color changes to red, and the user is notified that the event has been added to their bookmarks. As of right now it has no functionality. To unlike just press the button again, and it will be reverted back to its original color.

## Issue
Previously, if you saw an event in your announcements feed that you were interested in, there was no way to bookmark it. Now the like button on the event details page enables you to do that. 

### Usage 
1. Navigate to event details page
2. Press like button in top right corner

### Demo
https://user-images.githubusercontent.com/82081099/233860715-61fbc667-1be7-4035-b131-fddcbce62d7f.MP4


